### PR TITLE
Add module info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
 										org.bbottema.javareflection.util.commonslang25;
 										org.bbottema.javareflection.util.graph;
 										org.bbottema.javareflection.valueconverter;
+										org.bbottema.javareflection.valueconverter.converters;
 									</exports>
 								</moduleInfo>
 							</module>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,13 @@
 	</issueManagement>
 
 	<dependencies>
+		<dependency><!-- Gives us @NotNull and @Nullable -->
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>23.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.angus</groupId>
 			<artifactId>angus-activation</artifactId>
@@ -37,7 +44,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.2</version>
+			<version>1.18.32</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -55,4 +62,47 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.Final</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<jvmVersion>9</jvmVersion>
+							<module>
+								<moduleInfo>
+									<name>org.bbottema.javareflection</name>
+									<requires>
+										static org.jetbrains.annotations;
+										static com.github.spotbugs.annotations;
+										static lombok;
+										jakarta.activation;
+										slf4j.api;
+									</requires>
+									<exports>
+										org.bbottema.javareflection;
+										org.bbottema.javareflection.model;
+										org.bbottema.javareflection.util;
+										org.bbottema.javareflection.util.commonslang25;
+										org.bbottema.javareflection.util.graph;
+										org.bbottema.javareflection.valueconverter;
+									</exports>
+								</moduleInfo>
+							</module>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Adds a module info to the final build under `META-INF/versions/9`. This should not affect compatibility with java 8.

I'm working my way through the dependency tree of https://github.com/bbottema/simple-java-mail. 

For reference, I am producing these lists of exports/requires by upping the java version locally and then adding a module-info and following the compiler errors. While on Java 8 its sorta like guessing at what imports are needed at the top of a file without a compiler/IDE support.

For single modules like this its tenable, but if you are okay with upgrading past 8 at some point that would be helpful.